### PR TITLE
fix the http redirect return empty body

### DIFF
--- a/monkey_spec.js
+++ b/monkey_spec.js
@@ -107,7 +107,7 @@ describe("HTTP redirect:",function() {
 
   it("returns empty body",function(done) {
     request(app).get("/foo")
-      .expect("")
+      .expect(302, "")
       .expect("Content-Length",0).end(done);
   });
 });


### PR DESCRIPTION
在superagent的[History.md](https://github.com/visionmedia/superagent/blob/master/History.md#100--2015-03-08)中有这样的描述，在2015-3-18的版本中所有非200的status code都会throw
error。详见

另外，在supertest的./lib/[test.js](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L200-L212)代码写到，当测试status-code时（也就是使用expect(statusCode,[body])的
时候，会把由response传来的错误清空。其它类型的测试是不清空该error的。

综上，如果是需要测试非200的其它状态码的情况需要使用expect(statusCode,
[body])这样的格式。而expect(body)的格式适用于statusCode为200的情况。
